### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Fortnite VS Code Theme
 
+<div align="center">
+    
 ![Fortnite banner](/banner.png "Fortnite banner")
 
+</div>
+    
 🐔 Are you a child at heart? Do you like enjoying yourself, even while writing serious business logic? If you like taking a flame bow and igniting data structures on fire, this is the theme for you.
 
 This theme is inspired by Fortnite, which is a game that's basically like the Hunger Games set at children's birthday party in the middle of a fever dream. But more fun. Very cathartic for those of us in the tech industry.
@@ -11,11 +15,15 @@ Enjoy! 🛸
 
 ## Preview
 
+<div align="center">
+
 ![Theme preview screenshot](/theme.png "Theme preview screenshot")
+
+</div>
 
 ## Installation
 
-- Install the theme from the VS Marketplace - [fortnite-vscode-theme](https://marketplace.visualstudio.com/items?itemName=sarah.drasner.fortnite-vscode-theme)
+- Install the theme from the VS Marketplace - [fortnite-vscode-theme](https://marketplace.visualstudio.com/items?itemName=sarah.drasner.fortnite-vscode-theme).
 - To activate effects:
     1. Open your command palette with <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>Shift</kbd> + <kbd>⌘</kbd> + <kbd>P</kbd>.
     2. Choose "**Fortnite: Enable Legendary**". 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Fortnite VS Code Theme
 
-![Banner](https://raw.githubusercontent.com/sdras/fortnite-vscode-theme/master/banner.png?token=AARM5AGYHJWXNJOOUXLDWPLA4KA7I)
+<div align="center">
+  
+![Fortnite banner](/banner.png "Fortnite banner")
+
+</div>
 
 🐔 Are you a child at heart? Do you like enjoying yourself, even while writing serious business logic? If you like taking a flame bow and igniting data structures on fire, this is the theme for you.
 
@@ -8,17 +12,28 @@ This theme is inspired by Fortnite, which is a game that's basically like the Hu
 
 Enjoy! 🛸
 
-![Theme Screenshot](https://raw.githubusercontent.com/sdras/fortnite-vscode-theme/master/theme.png?token=AARM5AB5NAMRAZFOGGHM2QDA4OFCE)
+
+## Preview
+
+<div align="center">
+
+![Theme screenshot](/theme.png "Theme screenshot")
+  
+</div>
 
 ## Installation
 
-- Install the [theme from the VS Marketplace](https://marketplace.visualstudio.com/items?itemName=sarah.drasner.fortnite-vscode-theme)
-- To activate effects, open your command palette with `Ctrl + Shift + P` or `Shift + ⌘ + P` and choose "**Fortnite: Enable Legendary**". It will prompt you to restart, and when you'll see glows and other effects such activated. ✨
-- It will say VS Code is corrupted, but don't panic! This is not the case- we've modified some core files but it's not actually corrupted. You can safely dismiss it, either once or permanently with the instructions below.
+- Install the theme from the VS Marketplace - [fortnite-vscode-theme](https://marketplace.visualstudio.com/items?itemName=sarah.drasner.fortnite-vscode-theme)
+- To activate effects:
+    1. Open your command palette with <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>Shift</kbd> + <kbd>⌘</kbd> + <kbd>P</kbd>.
+    2. Choose "**Fortnite: Enable Legendary**". 
+    3. Follow the prompt to restart.
+    4. Then you'll see glows and other effects are activated. ✨
+- It will say VS Code is corrupted, but don't panic! This is not the case - we've modified some core files, but it's not actually corrupted. You can safely dismiss it, either once or permanently with the instructions below.
 - **Enjoy the chaos**
-- If the effects ever get to you, you can turn them off with **Fortnite: Disable Legendary**. De-activating and re-activating will reengage the llama.
+- If the effects ever get to you, you can turn them off with **Fortnite: Disable Legendary**. De-activating and re-activating will re-engage the llama.
 
-### To remove corruption warning and [unsupported] from title-bar
+### To remove corruption warning and `[unsupported]` from title-bar
 
 Because enabling the glow modifies core files, VS code will interpret this as the core being 'corrupted' and you may see an error message on restarting your editor. You can remove it entirely with the [Fix VSCode Checksums](https://marketplace.visualstudio.com/items?itemName=lehni.vscode-fix-checksums 'Fix VSCode Checksums') extension.
 
@@ -26,13 +41,22 @@ Upon installation of 'Fix VSCode Checksums', open the command palette and execut
 
 ### Disclaimer
 
-VS code doesn't natively support some of the... eccentricities of this theme and as a result, a lot of the effects are experimental. Should something go wrong, you can disable it by opening your command palette with `Ctrl + Shift + P` or `Shift + ⌘ + P` and choose "**Fortnite: Disable Legendary**", or if things go really awry, with a fresh install of VS Code.
+VS code doesn't natively support some of the... eccentricities of this theme. And, as a result, a lot of the effects are experimental. 
 
-If you are a Windows user, you may need to run VS Code with administrator privileges. For Linux and Mac users, Code must not be installed in a read-only location and you must have write permissions.
+Should something go wrong, you can disable it:
+
+1. Open your command palette with <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>Shift</kbd> + <kbd>⌘</kbd> + <kbd>P</kbd>.
+2. Choose "**Fortnite: Disable Legendary**".
+
+Or if things go really awry, get a fresh install of VS Code.
+
+If you are a Windows user, you may need to run VS Code with administrator privileges. 
+
+For Linux and Mac users, Code must not be installed in a read-only location and you must have write permissions.
 
 ## Updates
 
-Every time you update VS code, you will need to re-enable "**Fortnite: Enable Legendary**" in the command palette.
+Every time you update VS Code, you will need to re-enable "**Fortnite: Enable Legendary**" in the command palette.
 
 ## Contributing
 
@@ -48,4 +72,4 @@ I'm happy to consider any contributions to this theme, but it's experimental, pl
 
 ### Llama
 
-The source code for the llama [is also open sourced here.](https://codepen.io/sdras/pen/28c07e055d16636ae47aa154b0f933b8).
+The source code for the llama is also open sourced and can be found in this [codepen](https://codepen.io/sdras/pen/28c07e055d16636ae47aa154b0f933b8).

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Enjoy! 🛸
 
 <div align="center">
 
-![Theme preview screenshot](/theme.png "Theme preview screenshot")
+[![Theme preview screenshot](/theme.png "Theme preview screenshot")](https://marketplace.visualstudio.com/items?itemName=sdras.fortnite-vscode-theme)
 
 </div>
+
 
 ## Installation
 
@@ -41,7 +42,7 @@ Upon installation of 'Fix VSCode Checksums', open the command palette and execut
 
 ### Disclaimer
 
-VS code doesn't natively support some of the... eccentricities of this theme. And, as a result, a lot of the effects are experimental. 
+VS Code does not natively support some of the... eccentricities of this theme. And, as a result, a lot of the effects are _experimental_. 
 
 Should something go wrong, you can disable it:
 
@@ -64,7 +65,7 @@ I'm happy to consider any contributions to this theme, but it's experimental, pl
 
 ## Thanks
 
-- This theme is fan art for the great Fortnite game by Epic Games, it is open sourced under an MIT license and I make no ca$hmoney from it, it's just for fun.
+- This theme is fan art for the great Fortnite game by Epic Games, it is open-sourced under an MIT license and I make no ca$hmoney from it, it's just for fun.
 - Thanks to [Robb Owen](https://twitter.com/Robb0wen), whose Synthwave theme provided the basis to learn how to incorporate a lot of the legendary effects of this theme. The palette, though different, was also inspired by Robb's work. Thank you Robb!
 - Thanks also to [Mahmoud Ali](https://marketplace.visualstudio.com/publishers/akamud), whose Atom One Dark theme provided the basis for the samples included here.
 - Thanks to [Dizzy Smith](https://twitter.com/dizzyd) and [Ben Hong](https://twitter.com/bencodezen), who revive me when I get all pew pew pew.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Every time you update VS Code, you will need to re-enable "**Fortnite: Enable Le
 
 ## Contributing
 
-I'm happy to consider any contributions to this theme, but it's experimental, playful, and I don't expect to dedicate a ton of time to it. Before you make any changes, [please read the contribution guide](https://github.com/sdras/fortnite-vscode-theme/blob/master/CONTRIBUTING.md).
+I'm happy to consider any contributions to this theme, but it's experimental, playful, and I don't expect to dedicate a ton of time to it. 
+
+Before you make any changes, please read the [contribution guide](https://github.com/sdras/fortnite-vscode-theme/blob/master/CONTRIBUTING.md).
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Fortnite VS Code Theme
 
-<div align="center">
-  
 ![Fortnite banner](/banner.png "Fortnite banner")
-
-</div>
 
 🐔 Are you a child at heart? Do you like enjoying yourself, even while writing serious business logic? If you like taking a flame bow and igniting data structures on fire, this is the theme for you.
 
@@ -15,11 +11,7 @@ Enjoy! 🛸
 
 ## Preview
 
-<div align="center">
-
-![Theme screenshot](/theme.png "Theme screenshot")
-  
-</div>
+![Theme preview screenshot](/theme.png "Theme preview screenshot")
 
 ## Installation
 


### PR DESCRIPTION
Center images.

Use local reference to images `/banner.png` instead. This _still_ works in the extension when viewing outside of GitHub, based on my own extension. I took out `?token` - I can add back if needed.

Also added a link to clicking the preview takes you to the marketplace.

---

Add title attribute to images for SEO of the repo.

Use `kbd` for keyboard.

Break out instructions on multiple lines.

Remove extra dot at the end of the file around the llama link.